### PR TITLE
Fix add friends form

### DIFF
--- a/frontend/src/components/forms/AddFriends.js
+++ b/frontend/src/components/forms/AddFriends.js
@@ -66,7 +66,7 @@ const AddFriends = (props) => {
             <AsyncTypeahead
               id="typeahead-particpants"
               name="invitees"
-              labelKey={"username"}
+              labelKey="username"
               options={friendSuggestions}
               placeholder="Who's playing?"
               onSearch={handleSuggestions}


### PR DESCRIPTION
Add friends Typeahead wasn't bringing expected results. 

Made a small refactor of redundant function and changed typeahead `labelKey` to "username"