### PR TITLE
Changing sample time 

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -456,7 +456,7 @@ def suggest_friend_invites():
 @routes.route("/api/get_balances_chart", methods=["POST"])
 @authenticate
 def balances_chart():
-    """Be default, the frontend will load with username = null for the chart selector dropdown, and we'll show them
+    """By default, the frontend will load with username = null for the chart selector dropdown, and we'll show them
     their own chart. When the user proactively picks a username to checkout, this will be sent in the POST request to
     this endpoint and used to pull up the appropriate chart
     """


### PR DESCRIPTION
The `RESAMPLING_INTERVAL` set as a value of 5 means that the for any given day we would get 288 samples of the data per user per stock, running under `%timeit` on ipython the average time ven from `2.2` to `1.7` seconds.

[NOTE]  there might be conflicts with the current master branch because of tha changes been made there which could require us to change the logic of the functions here. In that case let's just shelf this PR and leave it as a possible improvement in the future. 

![image](https://user-images.githubusercontent.com/21244244/87103812-a799c700-c21b-11ea-89c1-47c948ccdc8c.png)
