### PR TITLE
Fix typo, suprrese .iloc false positive warning

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -36,7 +36,7 @@ class Config:
     DB_HOST = getenv("MYSQL_HOST")
     DB_PORT = getenv("MYSQL_PORT")
     DB_NAME = getenv("MYSQL_DATABASE")
-    SQLALCHEMY_DATABASE_URI = f"mysql+pymysql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}?charset=utf8"
+    SQLALCHEMY_DATABASE_URI = f"mysql+pymysql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}?charset=utf8mb4"
     SQLALCHEMY_TRACK_MODIFICATIONS = getenv("SQLALCHEMY_TRACK_MODIFICATIONS")
     SQLALCHEMY_ECHO = bool(getenv("SQLALCHEMY_ECHO") == "True")
     MIGRATIONS_DIRECTORY = "/home/backend/database/migrations"

--- a/backend/logic/base.py
+++ b/backend/logic/base.py
@@ -37,7 +37,7 @@ IEX_BASE_PROD_URL = "https://cloud.iexapis.com/"
 TIMEZONE = 'America/New_York'
 RESAMPLING_INTERVAL = 5  # resampling interval in minutes when building series of balances and prices
 nyse = mcal.get_calendar('NYSE')
-
+pd.options.mode.chained_assignment = None
 
 # ----------------------------------------------------------------------------------------------------------------- $
 # Time handlers. Pro tip: This is a _sensitive_ part of the code base in terms of testing. Times need to be mocked, #
@@ -347,7 +347,6 @@ def append_price_data_to_balance_histories(balances_df: pd.DataFrame) -> pd.Data
     resampled_balances = resampled_balances.reset_index().rename(columns={"level_1": "timestamp"})
     min_time = datetime_to_posix(resampled_balances["timestamp"].min())
     max_time = datetime_to_posix(resampled_balances["timestamp"].max())
-
     # Now add price data
     symbols = balances_df["symbol"].unique()
     price_df = get_price_histories(symbols, min_time, max_time)

--- a/backend/logic/payouts.py
+++ b/backend/logic/payouts.py
@@ -47,7 +47,7 @@ def portfolio_value_by_day(game_id: int, user_id: int, start_date: dt, end_date:
     return df.groupby("timestamp", as_index=False)["value"].sum()
 
 
-def porfolio_return_ratio(df: pd.DataFrame):
+def portfolio_return_ratio(df: pd.DataFrame):
     start_val = df.iloc[0]["value"]
     end_val = df.iloc[-1]["value"]
     return 100 * (end_val - start_val) / start_val
@@ -67,7 +67,7 @@ def portfolio_sharpe_ratio(df: pd.DataFrame, rf: float):
 def calculate_metrics(game_id: int, user_id: int, start_date: dt = None, end_date: dt = None,
                       rf: float = RISK_FREE_RATE_DEFAULT):
     df = portfolio_value_by_day(game_id, user_id, start_date, end_date)
-    return_ratio = porfolio_return_ratio(df)
+    return_ratio = portfolio_return_ratio(df)
     sharpe_ratio = portfolio_sharpe_ratio(df, rf)
     return return_ratio, sharpe_ratio
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -24,7 +24,7 @@ class TestConfig(unittest.TestCase):
         self.assertIsNotNone(DB_PORT)
         DB_NAME = getenv("MYSQL_DATABASE")
         self.assertIsNotNone(DB_NAME)
-        db_uri = f"mysql+pymysql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}?charset=utf8"
+        db_uri = f"mysql+pymysql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}?charset=utf8mb4"
         self.assertEqual(Config.SQLALCHEMY_DATABASE_URI, db_uri)
         self.assertIsNotNone(Config.SQLALCHEMY_DATABASE_URI)
         self.assertEqual(Config.SQLALCHEMY_TRACK_MODIFICATIONS, getenv("SQLALCHEMY_TRACK_MODIFICATIONS"))


### PR DESCRIPTION
This PR fixes the warning 

```
/usr/local/lib/python3.7/dist-packages/pymysql/cursors.py:170: Warning: (3719, "'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.")
``` 
and the Pandas false possitive warning 

```
/usr/local/lib/python3.7/dist-packages/pandas/core/indexing.py:845: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead
``` 