### PR TITLE
Change right col base width from 100vw to 100% in PlayGame

### DIFF
--- a/frontend/src/components/layout/Layout.js
+++ b/frontend/src/components/layout/Layout.js
@@ -192,7 +192,7 @@ const Sidebar = ({ children, className, ...props }) => (
 
 const GameContent = styled(Column)`
   @media screen and (min-width: ${breakpoints.md}){
-    max-width: calc(100vw - 330px);
+    max-width: calc(100% - 330px);
   }
 `
 

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -50,7 +50,7 @@ const RightCol = styled(Col)`
 
   @media screen and (min-width: ${breakpoints.md}){
     text-align: left;
-    padding: 8vw;
+    padding: 0 8vw;
     justify-content: flex-start;
 
     br{


### PR DESCRIPTION
Attends a layout bug in which the columns overlapped. 

Viewport Width units in Windows Chrome (and other chrome versions) take into account the scrollbar and this was making the two columns exceed the container width. 

The solution was to **change 100vw to 100%** in the column max-width value
